### PR TITLE
update vert.x to 3.8.3 and resolve deprecations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
     <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
 
-    <vertx.version>3.7.1</vertx.version>
+    <vertx.version>3.8.3</vertx.version>
     <junit-jupiter.version>5.4.0</junit-jupiter.version>
 
     <main.verticle>com.danielprinz.udemy.ping_pong.PingVerticle</main.verticle>

--- a/src/main/java/com/danielprinz/udemy/ping_pong/FuturesExample.java
+++ b/src/main/java/com/danielprinz/udemy/ping_pong/FuturesExample.java
@@ -2,33 +2,33 @@ package com.danielprinz.udemy.ping_pong;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 public class FuturesExample extends AbstractVerticle {
 
   @Override
-  public void start(final Future<Void> startFuture) throws Exception {
+  public void start(final Promise<Void> start) throws Exception {
     System.out.println("1 - Start");
-    Future<Void> whenTimer1Fired = Future.future();
+    Promise<Void> whenTimer1Fired = Promise.promise();
     vertx.setTimer(1000, id -> {
       System.out.println("3 - Timer fired");
       whenTimer1Fired.complete();
     });
-    Future<Void> whenTimer2Fired = Future.future();
+    Promise<Void> whenTimer2Fired = Promise.promise();
     vertx.setTimer(2000, id -> {
       System.out.println("4 - Second Timer fired");
       whenTimer2Fired.complete();
     });
-    CompositeFuture.all(whenTimer1Fired, whenTimer2Fired).setHandler(ar -> {
+    CompositeFuture.all(whenTimer1Fired.future(), whenTimer2Fired.future()).setHandler(ar -> {
       System.out.println("5 - Both timers fired");
-      startFuture.complete();
+      start.complete();
     });
     System.out.println("2 - Timer Execution Called");
   }
 
   @Override
-  public void stop(final Future<Void> stopFuture) throws Exception {
+  public void stop(final Promise<Void> stop) throws Exception {
     System.out.println("Stop");
   }
 

--- a/src/main/java/com/danielprinz/udemy/ping_pong/PingVerticle.java
+++ b/src/main/java/com/danielprinz/udemy/ping_pong/PingVerticle.java
@@ -21,7 +21,7 @@ public class PingVerticle extends AbstractVerticle {
   }
 
   private void sendPing() {
-    vertx.eventBus().send("ping-pong", new JsonObject().put("msg", "ping"), ar -> {
+    vertx.eventBus().request("ping-pong", new JsonObject().put("msg", "ping"), ar -> {
       if (ar.failed()) {
         System.err.println("Did not receive a response: " + ar.cause());
         return;

--- a/src/test/java/com/danielprinz/udemy/ping_pong/TestPongVerticle.java
+++ b/src/test/java/com/danielprinz/udemy/ping_pong/TestPongVerticle.java
@@ -28,7 +28,7 @@ public class TestPongVerticle {
   @Timeout(5000)
   @Test
   void pongIsReplied(Vertx vertx, VertxTestContext context) {
-    vertx.eventBus().send("ping-pong", "ping-test", reply -> {
+    vertx.eventBus().request("ping-pong", "ping-test", reply -> {
       if (reply.failed()) {
         context.failNow(reply.cause());
       } else {


### PR DESCRIPTION
This pull requests shows how to update from vert.x 3.7 to vert.x 3.8 and resolve the deprecations. By resolving the deprecations the application will be ready for the next major version 4 of the vert.x framework.